### PR TITLE
feat: java cors config

### DIFF
--- a/backend_java/src/main/java/edu/scu/studentvotingportal/config/CorsConfig.java
+++ b/backend_java/src/main/java/edu/scu/studentvotingportal/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package edu.scu.studentvotingportal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.addAllowedOrigin("*");
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.addAllowedMethod("*");
+        source.registerCorsConfiguration("/**", corsConfiguration);
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
## Title
Fix Java CORS config


## Summary
Java CORS is not supported correctly, so fix it.


## Test Plan
- Start frontend
  ```shell
  npm install --legacy-peer-deps
  npm start
  ```
- Start Java backend `./mvnw spring-boot:run`
- Call an backend endpoint via frontend
