### PR TITLE
fix: Header isLoggedIn

### DIFF
--- a/frontend/src/component/navigator/Header.tsx
+++ b/frontend/src/component/navigator/Header.tsx
@@ -17,8 +17,7 @@ function Header() {
   const [isAdmin, setIsAdmin] = React.useState(false);
   const [error, setError] = useState("");
   const [alertType, setAlertType] = useState("danger");
-
-  const isLoggedIn = currentUser.isLoggedIn();
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
 
   const redirectToHome = useCallback(() => {
@@ -41,6 +40,7 @@ function Header() {
       }
       const user = await currentUser.getUser();
       Logger.debug("[Header] loaded user: ", user);
+      setIsLoggedIn(currentUser.isLoggedIn())
       if (user.email !== "") {
         setIsAdmin(user.staff || user.superuser);
         setShowError(false);
@@ -52,7 +52,7 @@ function Header() {
       }
     };
     loadUserType();
-  }, [isLoggedIn, redirectToHome]);
+  }, [redirectToHome]);
 
   // Error alert
   const [showError, setShowError] = useState(false);
@@ -74,6 +74,7 @@ function Header() {
   const logout = async () => {
     const result = await myApi.deleteLogin();
     currentUser.removeUser();
+    setIsLoggedIn(currentUser.isLoggedIn())
     if (result.msg) {
       Logger.error("[Header] Logout error:", result.msg);
     }

--- a/frontend/src/component/navigator/Header.tsx
+++ b/frontend/src/component/navigator/Header.tsx
@@ -98,7 +98,7 @@ function Header() {
             <Nav>
               <Nav.Link href="/">Elections</Nav.Link>
               <NavDropdown title="Account" id="basic-nav-dropdown">
-                {isLoggedIn ? (
+                {isLoggedIn || currentUser.isLoggedIn() ? (
                   <>
                     <NavDropdown.Item disabled className="custom-disabled-item">{currentUser.email}</NavDropdown.Item>
                     <NavDropdown.Divider />


### PR DESCRIPTION
## Title
Fix frontend `<Header/>` `isLoggedIn`


## Summary
`isLoggedIn` is buggy. After a user logged-in, when click back to homepage or refresh, the log-in state is gone.
Therefore, we need to fix it.

<img width="1214" alt="image" src="https://github.com/blue86321/student-voting-portal/assets/50546951/46e9a680-6bb4-4959-b3bd-7aa245387379">



## Test Plan
- `docker compose up`
- Login
- Refresh page or click homepage
